### PR TITLE
User id verification

### DIFF
--- a/src/app/layout/navbar-layout/navbar-layout.component.ts
+++ b/src/app/layout/navbar-layout/navbar-layout.component.ts
@@ -54,21 +54,10 @@ export class NavbarLayoutComponent implements OnInit {
 
   public logout() {
     this.router.navigate(['auth', 'logout']);
-    // this.authorizationService.revokeToken().subscribe((r1: any) => {
-    //   this.authorizationService.clearStorage();
-    //   return this.authorizationService.logout().subscribe((r2: any) => {
-    //     this.authorizationService.authorize();
-    //   });
-    // });
   }
 
   public openSiginAsModal() {
-    const dialogRef = this.dialog.open(SigninAsDialogComponent, {
-      width: '568px',
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-    });
+    this.dialog.open(SigninAsDialogComponent, { width: '568px' });
   }
 
   public pulse() {

--- a/src/app/modules/users/page/user-details/user-details.component.ts
+++ b/src/app/modules/users/page/user-details/user-details.component.ts
@@ -73,8 +73,9 @@ export class UserDetailsComponent implements OnInit {
   }
 
   public missingInformations() {
-    const ai = this.currentUser.additionalInformation;
-    if (ai && ai.accountingDepartment && ai.birthDate && ai.role && this.activatedRoute.snapshot.params.id === this.currentUser.id) {
+    const currentUser = User.fromLocalStorage();
+    const ai = currentUser.additionalInformation;
+    if (ai && ai.accountingDepartment && ai.birthDate && ai.role && this.activatedRoute.snapshot.params.id === currentUser.id) {
       this.missingInformations = () => false;
       return false;
     }

--- a/src/app/modules/users/page/user-details/user-details.component.ts
+++ b/src/app/modules/users/page/user-details/user-details.component.ts
@@ -73,8 +73,8 @@ export class UserDetailsComponent implements OnInit {
   }
 
   public missingInformations() {
-    const ai = User.fromLocalStorage().additionalInformation;
-    if (ai && ai.accountingDepartment && ai.birthDate && ai.role) {
+    const ai = this.currentUser.additionalInformation;
+    if (ai && ai.accountingDepartment && ai.birthDate && ai.role && this.activatedRoute.snapshot.params.id === this.currentUser.id) {
       this.missingInformations = () => false;
       return false;
     }

--- a/src/app/modules/users/page/user-details/user-details.component.ts
+++ b/src/app/modules/users/page/user-details/user-details.component.ts
@@ -75,7 +75,7 @@ export class UserDetailsComponent implements OnInit {
   public missingInformations() {
     const currentUser = User.fromLocalStorage();
     const ai = currentUser.additionalInformation;
-    if (ai && ai.accountingDepartment && ai.birthDate && ai.role && this.activatedRoute.snapshot.params.id === currentUser.id) {
+    if ((ai && ai.accountingDepartment && ai.birthDate && ai.role) || this.activatedRoute.snapshot.params.id !== currentUser.id) {
       this.missingInformations = () => false;
       return false;
     }


### PR DESCRIPTION
### Qual era o problema?

> Quando um usuário administrador (tipo 0) que não tinha as Informações Extras entrava na tela de informações de usuário de OUTRO usuário, o sistema o obrigava a preencher as informações adicionais e ao salvar, elas não eram salvas para o administrador mas sim para o outro usuário.

### Como ele foi resolvido? 

> Adicionando uma verificação de usuário. Pois embora essa verificação já existisse no botão "Informações Extras", ela não era feita no autoredirect

### Qual o resultado esperado? 

> Ao se entrar nas informações de um usuário (que não seja você mesmo) utilizando um usuário do tipo 0, não mais será movido para a aba de informações adicionais
